### PR TITLE
Fix `setup_env.sh` in language_models

### DIFF
--- a/pytorch/language-models/setup_env.sh
+++ b/pytorch/language-models/setup_env.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # --- 1. CLI의 첫 번째 인자를 VFOLDER_NAME 변수에 할당 ---
-# 인자가 제공되지 않았을 경우, 에러 메시지를 출력하고 스크립트를 종료합니다.
 if [ -z "$1" ]; then
     echo "❌ Error: Please provide the base path for your vfolder as the first argument."
     echo "Usage: ./setup_venv.sh /path/to/your/vfolder"
@@ -12,18 +11,26 @@ VFOLDER_NAME=$1
 # --------------------------------------------------------
 
 VENV_PATH="/pipeline/vfroot/.venv"
-REQUIREMENTS_PATH="/${VFOLDER_NAME}/backend.ai-fasttrack-examples/pytorch/gemma-3n/pipeline-code/requirements.txt"
+REQUIREMENTS_PATH="${VFOLDER_NAME}/backend.ai-fasttrack-examples/pytorch/language-models/pipeline-code/requirements.txt"
 
 echo "Using base path: $VFOLDER_NAME"
 
-# 가상 환경이 존재하는지 확인
+# 2. 가상 환경이 존재하는지 확인하고, 없으면 새로 생성합니다.
 if [ ! -d "$VENV_PATH" ]; then
-    echo "Virtual environment not found. Creating a new one at $VENV_PATH"
+    echo "Virtual environment not found. Creating a new one at $VENV_PATH..."
     python -m venv "$VENV_PATH"
-    source "$VENV_PATH/bin/activate"
-    pip install -r "$REQUIREMENTS_PATH"
 else
-    echo "Existing virtual environment found at $VENV_PATH. Skipping creation and installation."
+    echo "Existing virtual environment found at $VENV_PATH."
 fi
-# 가상 환경 활성화 및 패키지 설치
+
+# 3. 공통 작업: 항상 패키지를 설치하거나 확인합니다.
+echo "Installing or verifying packages from $REQUIREMENTS_PATH..."
+"$VENV_PATH/bin/pip" install -r "$REQUIREMENTS_PATH"
+
+# -----------------------------
+
+# 4. 사용자에게 다음 행동을 안내합니다.
+echo ""
 echo "✅ Virtual environment setup complete."
+echo "To activate the environment, run the following command in your terminal:"
+echo "source $VENV_PATH/bin/activate"


### PR DESCRIPTION
This PR makes setup_env.sh more flexible and safer, and updates the related paths accordingly.
Now, the updated script can be used in the language_models pipeline.